### PR TITLE
update init error message to say WebDriver instead of selenium

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -9,7 +9,7 @@ void function () {
     url = '' + serverUrl + '/session';
     data = JSON.stringify({ desiredCapabilities: desiredCapabilities });
     response = request(url, 'POST', data);
-    assert.equal('Failed to start Selenium session. Check the selenium.log.', response.statusCode, 200);
+    assert.equal('Failed to start WebDriver session.', response.statusCode, 200);
     sessionId = json.tryParse(response.body.toString()).sessionId;
     capabilities = parseResponseData(response);
     assert.truthy('found sessionId', sessionId);

--- a/src/session.coffee
+++ b/src/session.coffee
@@ -39,7 +39,7 @@ module.exports = (request, serverUrl, desiredCapabilities) ->
   data = JSON.stringify { desiredCapabilities }
   response = request(url, 'POST', data)
 
-  assert.equal 'Failed to start Selenium session. Check the selenium.log.', response.statusCode, 200
+  assert.equal 'Failed to start WebDriver session.', response.statusCode, 200
 
   sessionId = (json.tryParse response.body.toString()).sessionId
   capabilities = parseResponseData response


### PR DESCRIPTION
WebDriver shouldn't know or care about how it's being used. Changed the error message to simply say it failed to start a WebDriver session.

Addresses: https://github.com/groupon-testium/webdriver-http-sync/issues/20