### PR TITLE
better error reporting for timeouts; fix internal timeout api usage

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -43,16 +43,9 @@ TIMEOUT = 60000;
 
 CONNECT_TIMEOUT = 2000;
 
-makeResponse = function(error, arg) {
+makeResponse = function(arg) {
   var body, headers, lcHeaders, name, ref, statusCode, value;
   ref = arg != null ? arg : {}, headers = ref.headers, body = ref.body, statusCode = ref.statusCode;
-  if (error != null) {
-    return {
-      headers: {},
-      body: error.stack,
-      statusCode: 408
-    };
-  }
   lcHeaders = {};
   for (name in headers) {
     value = headers[name];
@@ -75,7 +68,7 @@ module.exports = function(arg) {
     connectTimeout = CONNECT_TIMEOUT;
   }
   return function(url, method, data) {
-    var body, error, options, req, result;
+    var body, options, req, result;
     if (method == null) {
       method = 'GET';
     }
@@ -93,14 +86,13 @@ module.exports = function(arg) {
     };
     req = request(options);
     req.write(body);
-    error = null;
     req.setTimeout(timeout, function() {
-      return error = new Error("Request timed out after " + timeout + "ms to: " + url);
+      throw new Error("Request timed out after " + timeout + "ms to: " + url);
     });
     req.setConnectTimeout(connectTimeout, function() {
-      return error = new Error("Request connection timed out after " + connectTimeout + "ms to: " + url);
+      throw new Error("Request connection timed out after " + connectTimeout + "ms to: " + url);
     });
     result = req.end();
-    return makeResponse(error, result);
+    return makeResponse(result);
   };
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -43,9 +43,16 @@ TIMEOUT = 60000;
 
 CONNECT_TIMEOUT = 2000;
 
-makeResponse = function(arg) {
-  var body, headers, lcHeaders, name, statusCode, value;
-  headers = arg.headers, body = arg.body, statusCode = arg.statusCode;
+makeResponse = function(error, arg) {
+  var body, headers, lcHeaders, name, ref, statusCode, value;
+  ref = arg != null ? arg : {}, headers = ref.headers, body = ref.body, statusCode = ref.statusCode;
+  if (error != null) {
+    return {
+      headers: {},
+      body: error.stack,
+      statusCode: 408
+    };
+  }
   lcHeaders = {};
   for (name in headers) {
     value = headers[name];
@@ -68,7 +75,7 @@ module.exports = function(arg) {
     connectTimeout = CONNECT_TIMEOUT;
   }
   return function(url, method, data) {
-    var body, options, req, result;
+    var body, error, options, req, result;
     if (method == null) {
       method = 'GET';
     }
@@ -86,9 +93,14 @@ module.exports = function(arg) {
     };
     req = request(options);
     req.write(body);
-    req.setTimeout(timeout);
-    req.setConnectTimeout(connectTimeout);
+    error = null;
+    req.setTimeout(timeout, function() {
+      return error = new Error("Request timed out after " + timeout + "ms to: " + url);
+    });
+    req.setConnectTimeout(connectTimeout, function() {
+      return error = new Error("Request connection timed out after " + connectTimeout + "ms to: " + url);
+    });
     result = req.end();
-    return makeResponse(result);
+    return makeResponse(error, result);
   };
 };

--- a/lib/session.js
+++ b/lib/session.js
@@ -40,12 +40,18 @@ json = require('./json');
 parseResponseData = require('./parse_response');
 
 module.exports = function(request, serverUrl, desiredCapabilities) {
-  var capabilities, data, response, sessionId, url;
+  var capabilities, data, error, response, sessionId, url;
   url = serverUrl + "/session";
   data = {
     desiredCapabilities: desiredCapabilities
   };
-  response = request(url, 'POST', data);
+  try {
+    response = request(url, 'POST', data);
+  } catch (_error) {
+    error = _error;
+    error.message = "Failed to start WebDriver session: " + error.message;
+    throw error;
+  }
   assert.equal("Failed to start WebDriver session: " + response.body, response.statusCode, 200);
   sessionId = (json.tryParse(response.body.toString())).sessionId;
   capabilities = parseResponseData(response);

--- a/lib/session.js
+++ b/lib/session.js
@@ -46,7 +46,7 @@ module.exports = function(request, serverUrl, desiredCapabilities) {
     desiredCapabilities: desiredCapabilities
   };
   response = request(url, 'POST', data);
-  assert.equal('Failed to start WebDriver session.', response.statusCode, 200);
+  assert.equal("Failed to start WebDriver session: " + response.body, response.statusCode, 200);
   sessionId = (json.tryParse(response.body.toString())).sessionId;
   capabilities = parseResponseData(response);
   assert.truthy('found sessionId', sessionId);

--- a/src/request.coffee
+++ b/src/request.coffee
@@ -38,10 +38,7 @@ debug = require('debug')('webdriver-http-sync:request')
 TIMEOUT = 60000
 CONNECT_TIMEOUT = 2000
 
-makeResponse = (error, {headers, body, statusCode}={}) ->
-  if error?
-    return {headers: {}, body: error.stack, statusCode: 408}
-
+makeResponse = ({headers, body, statusCode}={}) ->
   lcHeaders = {}
   for name, value of headers
     lcHeaders[name.toLowerCase()] = value
@@ -68,11 +65,10 @@ module.exports = ({timeout, connectTimeout} = {}) ->
     req = request options
     req.write body
 
-    error = null
     req.setTimeout timeout, ->
-      error = new Error "Request timed out after #{timeout}ms to: #{url}"
+      throw new Error "Request timed out after #{timeout}ms to: #{url}"
     req.setConnectTimeout connectTimeout, ->
-      error = new Error "Request connection timed out after #{connectTimeout}ms to: #{url}"
+      throw new Error "Request connection timed out after #{connectTimeout}ms to: #{url}"
 
     result = req.end()
-    makeResponse error, result
+    makeResponse result

--- a/src/session.coffee
+++ b/src/session.coffee
@@ -39,7 +39,7 @@ module.exports = (request, serverUrl, desiredCapabilities) ->
   data = { desiredCapabilities }
   response = request(url, 'POST', data)
 
-  assert.equal 'Failed to start WebDriver session.', response.statusCode, 200
+  assert.equal "Failed to start WebDriver session: #{response.body}", response.statusCode, 200
 
   sessionId = (json.tryParse response.body.toString()).sessionId
   capabilities = parseResponseData response

--- a/src/session.coffee
+++ b/src/session.coffee
@@ -37,7 +37,12 @@ parseResponseData = require './parse_response'
 module.exports = (request, serverUrl, desiredCapabilities) ->
   url = "#{serverUrl}/session"
   data = { desiredCapabilities }
-  response = request(url, 'POST', data)
+
+  try
+    response = request(url, 'POST', data)
+  catch error
+    error.message = "Failed to start WebDriver session: #{error.message}"
+    throw error
 
   assert.equal "Failed to start WebDriver session: #{response.body}", response.statusCode, 200
 

--- a/test/driver.test.coffee
+++ b/test/driver.test.coffee
@@ -13,10 +13,13 @@ webUrl = "http://127.0.0.1:#{webPort}/"
 webTitle = 'A title'
 testServer = path.join __dirname, 'test-server'
 
+DEBUG = false
+
 describe 'Webdriver', ->
   before 'example website', (done) ->
     @server = execFile testServer, [ '' + webPort ]
     @server.stderr.pipe process.stderr
+    @server.stdout.pipe process.stdout if DEBUG
     setTimeout done, 200
 
   before 'boot phantomjs', (done) ->
@@ -24,6 +27,8 @@ describe 'Webdriver', ->
     @phantom = execFile 'phantomjs', phantomArgs
     phantomOut = ''
     @phantom.on 'error', done
+    @phantom.stdout.pipe process.stdout if DEBUG
+    @phantom.stderr.pipe process.stderr if DEBUG
 
     waitForBoot = (chunk) =>
       phantomOut += chunk.toString 'utf8'
@@ -37,6 +42,8 @@ describe 'Webdriver', ->
   before 'create driver', ->
     @driver = new WebDriver "#{phantomUrl}", {
       browserName: 'phantomjs'
+    },{
+      timeout: 3000
     }
 
   after 'close session', ->

--- a/test/driver.test.coffee
+++ b/test/driver.test.coffee
@@ -10,6 +10,7 @@ phantomUrl = "http://127.0.0.1:#{phantomPort}"
 
 webPort = 4497
 webUrl = "http://127.0.0.1:#{webPort}/"
+timeoutUrl = "#{webUrl}timeout"
 webTitle = 'A title'
 testServer = path.join __dirname, 'test-server'
 
@@ -43,7 +44,7 @@ describe 'Webdriver', ->
     @driver = new WebDriver "#{phantomUrl}", {
       browserName: 'phantomjs'
     },{
-      timeout: 3000
+      timeout: 1000
     }
 
   after 'close session', ->
@@ -55,25 +56,31 @@ describe 'Webdriver', ->
   after 'tear down test-server', ->
     try @server?.kill()
 
-  before 'navigate to a page', ->
-    @driver.navigateTo webUrl
+  describe 'at timeout url', ->
+    it 'throws an error when a request times out', ->
+      error = assert.throws => @driver.navigateTo timeoutUrl
+      assert.include /Request connection timed out/, error.message
 
-  it 'can get the page title', ->
-    assert.equal webTitle, @driver.getPageTitle()
+  describe 'at working url', ->
+    before 'navigate to a page', ->
+      @driver.navigateTo webUrl
 
-  it 'can get the url', ->
-    assert.equal webUrl, @driver.getUrl()
+    it 'can get the page title', ->
+      assert.equal webTitle, @driver.getPageTitle()
 
-  describe 'unicode support', ->
-    multibyteText = "日本語 text"
+    it 'can get the url', ->
+      assert.equal webUrl, @driver.getUrl()
 
-    it 'supports reading unicode input values', ->
-      element = @driver.getElement '#unicode-input'
-      result = element.get('value')
-      assert.equal multibyteText, result
+    describe 'unicode support', ->
+      multibyteText = "日本語 text"
 
-    it 'supports setting unicode input values', ->
-      element = @driver.getElement '#blank-input'
-      element.type multibyteText
-      result = element.get('value')
-      assert.equal multibyteText, result
+      it 'supports reading unicode input values', ->
+        element = @driver.getElement '#unicode-input'
+        result = element.get('value')
+        assert.equal multibyteText, result
+
+      it 'supports setting unicode input values', ->
+        element = @driver.getElement '#blank-input'
+        element.type multibyteText
+        result = element.get('value')
+        assert.equal multibyteText, result

--- a/test/test-server
+++ b/test/test-server
@@ -37,6 +37,9 @@ function respondJSON(req, res) {
 }
 
 function handler(req, res) {
+  if (req.url == '/timeout') {
+    return; //time out
+  }
   if (/^\/json/.test(req.url)) {
     return respondJSON(req, res);
   }


### PR DESCRIPTION
I'm getting a timeout running the tests locally. I noticed that the timeout registration was broken. So, I fixed that, but I'm still not sure why I'm seeing a timeout here.

```
$ npm test

> webdriver-http-sync@1.0.0 pretest /home/sean/source/webdriver-http-sync
> npm run build


> webdriver-http-sync@1.0.0 build /home/sean/source/webdriver-http-sync
> npub prep && coffee -cbo lib src


> webdriver-http-sync@1.0.0 test /home/sean/source/webdriver-http-sync
> mocha


  Webdriver
PhantomJS is launching GhostDriver...
[INFO  - 2015-03-18T15:11:31.640Z] GhostDriver - Main - running on port 4499
    1) "before all" hook: create driver

  request
[INFO  - 2015-03-18T15:11:31.652Z] Session [0f249b10-cd81-11e4-a732-8f5dc8231bc4] - CONSTRUCTOR - Desired Capabilities: {"browserName":"phantomjs"}
[INFO  - 2015-03-18T15:11:31.652Z] Session [0f249b10-cd81-11e4-a732-8f5dc8231bc4] - CONSTRUCTOR - Negotiated Capabilities: {"browserName":"phantomjs","version":"1.9.0","driverName":"ghostdriver","driverVersion":"1.0.3","platform":"linux-unknown-64bit","javascriptEnabled":true,"takesScreenshot":true,"handlesAlerts":false,"databaseEnabled":false,"locationContextEnabled":false,"applicationCacheEnabled":false,"browserConnectionEnabled":false,"cssSelectorsEnabled":true,"webStorageEnabled":false,"rotatable":false,"acceptSslCerts":false,"nativeEvents":true,"proxy":{"proxyType":"direct"}}
[INFO  - 2015-03-18T15:11:31.652Z] SessionManagerReqHand - _postNewSessionCommand - New Session Created: 0f249b10-cd81-11e4-a732-8f5dc8231bc4
    ✓ sends a GET request 
    ✓ sends a POST request 


  2 passing (4s)
  1 failing

  1) Webdriver "before all" hook: create driver:
     Error: Assertion failed: Failed to start WebDriver session: Error: Request connection timed out after 2000ms to: http://127.0.0.1:4499/session
  at Object.callback (/home/sean/source/webdriver-http-sync/lib/request.js:101:22)
  at Object.CurlRequest.end (/home/sean/source/webdriver-http-sync/node_modules/http-sync/http-sync.js:86:34)
  at /home/sean/source/webdriver-http-sync/lib/request.js:103:18
  at module.exports (/home/sean/source/webdriver-http-sync/lib/session.js:48:14)
  at new WebDriver (/home/sean/source/webdriver-http-sync/lib/index.js:75:11)
  at Context.<anonymous> (/home/sean/source/webdriver-http-sync/test/driver.test.coffee:43:19)
  at callFn (/home/sean/source/webdriver-http-sync/node_modules/mocha/lib/runnable.js:266:21)
  at Hook.Runnable.run (/home/sean/source/webdriver-http-sync/node_modules/mocha/lib/runnable.js:259:7)
  at next (/home/sean/source/webdriver-http-sync/node_modules/mocha/lib/runner.js:268:10)
  at /home/sean/source/webdriver-http-sync/node_modules/mocha/lib/runner.js:284:7
  at done (/home/sean/source/webdriver-http-sync/node_modules/mocha/lib/runnable.js:222:5)
  at /home/sean/source/webdriver-http-sync/node_modules/mocha/lib/runnable.js:242:9
  at Socket.<anonymous> (/home/sean/source/webdriver-http-sync/test/driver.test.coffee:38:9)
  at Socket.emit (events.js:117:20)
  at Socket.<anonymous> (_stream_readable.js:765:14)
  at Socket.emit (events.js:92:17)
  at emitReadable_ (_stream_readable.js:427:10)
  at emitReadable (_stream_readable.js:423:5)
  at readableAddChunk (_stream_readable.js:166:9)
  at Socket.Readable.push (_stream_readable.js:128:10)
  at Pipe.onread (net.js:529:21)

Expected: 408
Actually: 200
    at error (/home/sean/source/webdriver-http-sync/node_modules/assertive/lib/assertive.js:441:12)
    at Object.assert.equal (/home/sean/source/webdriver-http-sync/node_modules/assertive/lib/assertive.js:105:15)
    at module.exports (/home/sean/source/webdriver-http-sync/lib/session.js:49:10)
    at new WebDriver (/home/sean/source/webdriver-http-sync/lib/index.js:75:11)
    at Context.<anonymous> (/home/sean/source/webdriver-http-sync/test/driver.test.coffee:43:19)
    at callFn (/home/sean/source/webdriver-http-sync/node_modules/mocha/lib/runnable.js:266:21)
    at Hook.Runnable.run (/home/sean/source/webdriver-http-sync/node_modules/mocha/lib/runnable.js:259:7)
    at next (/home/sean/source/webdriver-http-sync/node_modules/mocha/lib/runner.js:268:10)
    at /home/sean/source/webdriver-http-sync/node_modules/mocha/lib/runner.js:284:7
    at done (/home/sean/source/webdriver-http-sync/node_modules/mocha/lib/runnable.js:222:5)
    at /home/sean/source/webdriver-http-sync/node_modules/mocha/lib/runnable.js:242:9
    at Socket.<anonymous> (/home/sean/source/webdriver-http-sync/test/driver.test.coffee:38:9)
    at Socket.emit (events.js:117:20)
    at Socket.<anonymous> (_stream_readable.js:765:14)
    at Socket.emit (events.js:92:17)
    at emitReadable_ (_stream_readable.js:427:10)
    at emitReadable (_stream_readable.js:423:5)
    at readableAddChunk (_stream_readable.js:166:9)
    at Socket.Readable.push (_stream_readable.js:128:10)
    at Pipe.onread (net.js:529:21)
  

npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```